### PR TITLE
Feature/key value or nil

### DIFF
--- a/lib/fdoc/endpoint.rb
+++ b/lib/fdoc/endpoint.rb
@@ -116,7 +116,10 @@ class Fdoc::Endpoint
   end
 
   def get_nested_hash_value_by_keys(hash, keys)
-    keys.inject(hash) { |h, key| h[key] unless h.nil? }
+    keys.inject(hash) do |h, key|
+      return if h.nil?
+      key == 'items' ? h.first : h[key]
+    end
   end
 
   def verb

--- a/lib/fdoc/endpoint.rb
+++ b/lib/fdoc/endpoint.rb
@@ -94,7 +94,7 @@ class Fdoc::Endpoint
     if schema['type'] == 'key_value' &&
         (hash_schema = schema['properties']).is_a?(Hash) &&
         hash_schema.size == 1
-      
+
       schema['type'] = 'object'
       response_hash = get_nested_hash_value_by_keys(params, path)
       item_schema = hash_schema.delete(hash_schema.keys.first)
@@ -116,7 +116,7 @@ class Fdoc::Endpoint
   end
 
   def get_nested_hash_value_by_keys(hash, keys)
-    keys.inject(hash) { |h, key| h[key] }
+    keys.inject(hash) { |h, key| h[key] unless h.nil? }
   end
 
   def verb


### PR DESCRIPTION
This allows for a key_value type to be nested within an object that could also be nil.
For example:
```
property
  type: [object, nil]
  properties:
    kv_property:
      type: key_value
```

Also allows the key_value type to be used within an array.
```
property
  type: array
  items:
    type: key_value
```