### PR TITLE
Updating access of nested hash value

### DIFF
--- a/lib/fdoc/endpoint.rb
+++ b/lib/fdoc/endpoint.rb
@@ -118,7 +118,7 @@ class Fdoc::Endpoint
   def get_nested_hash_value_by_keys(hash, keys)
     keys.inject(hash) do |h, key|
       return if h.nil?
-      key == 'items' ? h.first : h[key]
+      h.is_a?(Array) ? h.first : h[key]
     end
   end
 


### PR DESCRIPTION
There was an issue that if a key_value type was used at a lower depth than a [object, array] type, then the value couldn't properly be accessed. This is mostly because of the 'items' key not being available.