### PR TITLE
Fix key-value type to support nesting of many hash objects

### DIFF
--- a/lib/fdoc/endpoint.rb
+++ b/lib/fdoc/endpoint.rb
@@ -101,7 +101,7 @@ class Fdoc::Endpoint
 
       if response_hash.present?
         response_hash.each do |k, v|
-          hash_schema[k] = item_schema
+          hash_schema[k] = item_schema.deep_dup
         end
       end
     end


### PR DESCRIPTION
Allows deep nesting of key_value types with multiple key/value pairs.