### PR TITLE
Raise on error in include builder

### DIFF
--- a/lib/fdoc/endpoint.rb
+++ b/lib/fdoc/endpoint.rb
@@ -38,7 +38,7 @@ class Fdoc::Endpoint
         replace_includes(@schema, includes)
       rescue => e
         puts "#{e.message} (from #{@path})"
-        exit
+        raise
       end
     end
 


### PR DESCRIPTION
When we exit from here, it breaks the expected behaviour for Rspec.

In particular, when the fdoc file does not exist, rspec ends early and
rspec_junit_formatter cannot find a status for the example as it did not
complete