### PR TITLE
Use ruby <= 2.6 arguments style

### DIFF
--- a/lib/fdoc/spec_watcher.rb
+++ b/lib/fdoc/spec_watcher.rb
@@ -5,13 +5,14 @@ module Fdoc
     VERBS = [:get, :post, :put, :patch, :delete]
 
     VERBS.each do |verb|
-      define_method(verb) do |*params|
+      m = define_method(verb) do |*params|
         action, request_params = params
 
         super(*params)
 
         check_response(verb, request_params) if path
       end
+      m.ruby2_keywords if m.respond_to?(:ruby2_keywords)
     end
 
     private


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

ruby 2.7 warns of a future breaking change in ruby 3.0 to keyword arguments.
Use backward compatibility marker ruby2_keywords if present